### PR TITLE
Copy button and formatting changes

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,19 +1,73 @@
 window.onload=function(){
-// Decide if this is a private repo by looking for a Label with the text "Private"
-function isPrivateRepo() {
-  var outlineLabels = document.querySelectorAll(
-    "span.Label.Label--outline.v-align-middle"
-  );
-  for (const label of outlineLabels) {
-    if (label.innerText == "Private") {
-      return true;
+  // Decide if this is a private repo by looking for a Label with the text "Private"
+  function isPrivateRepo() {
+    var outlineLabels = document.querySelectorAll(
+      "span.Label.Label--outline.v-align-middle"
+    );
+    for (const label of outlineLabels) {
+      if (label.innerText == "Private") {
+        return true;
+      }
     }
+    return false;
   }
-  return false;
-}
 
-if (isPrivateRepo()) {
-  // Set the background color of the header to dark red.
-  document.querySelectorAll("header")[0].style.backgroundColor = "darkRed";
-}
+  // Copy a formatted link to the GitHub issue
+  function addCopyButton() {
+    var element = document.createElement("input");
+    element.type = 'button';
+    element.value = 'Copy';
+    element.style.marginRight="20px";
+    element.onclick = function() {
+      var title = document.getElementsByClassName('js-issue-title')[0].innerText;
+      var href = window.location.href;
+      var id = href.substr(href.lastIndexOf('/') + 1);
+
+      var div = document.createElement('div');
+      div.appendChild(document.createTextNode(title));
+      var a = document.createElement('a');
+      var linkText = document.createTextNode('#' + id);
+      a.appendChild(linkText);
+      a.href = href;
+      div.appendChild(a);
+      document.body.appendChild(div);
+
+      const range = document.createRange();
+      range.selectNode(div);
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+      const successful = document.execCommand('copy');
+      document.body.removeChild(div);
+
+    };
+    document.getElementsByClassName('Header')[0].prepend(element);
+  }
+
+  if (isPrivateRepo()) {
+    // Set the background color of the header to dark red and a line down the margin
+    document.querySelectorAll("header")[0].style.backgroundColor = "darkRed";
+    var div = document.createElement('div');
+    div.style.width="10px";
+    div.style.backgroundColor="darkRed";
+    div.style.position = "fixed";
+    div.style.top = "0";
+    div.style.left = "0";
+    div.style.bottom = "0";
+    document.body.appendChild(div);
+  }
+  else {
+    // Set the background color of the header to dark blue and a line down the margin
+    document.querySelectorAll("header")[0].style.backgroundColor = "darkBlue";
+    var div = document.createElement('div');
+    div.style.width="10px";
+    div.style.backgroundColor="darkBlue";
+    div.style.position = "fixed";
+    div.style.top = "0";
+    div.style.left = "0";
+    div.style.bottom = "0";
+    document.body.appendChild(div);
+  }
+
+  addCopyButton();
 }

--- a/content.js
+++ b/content.js
@@ -14,9 +14,11 @@ window.onload=function(){
 
   // Copy a formatted link to the GitHub issue
   function addCopyButton() {
+    if (document.getElementById('extensionCopyButton')) return;
     var element = document.createElement("input");
     element.type = 'button';
-    element.value = 'Copy';
+    element.value = 'Copy Formatted';
+    element.id = 'extensionCopyButton'
     element.style.marginRight="20px";
     element.onclick = function() {
       var title = document.getElementsByClassName('js-issue-title')[0].innerText;
@@ -39,7 +41,34 @@ window.onload=function(){
       selection.addRange(range);
       const successful = document.execCommand('copy');
       document.body.removeChild(div);
+    };
+    document.getElementsByClassName('Header')[0].prepend(element);
+  }
 
+  // Add a button to copy link title and URL in MD format
+  function addCopyMarkdownButton() {
+    if (document.getElementById('extensionCopyButtonMarkdown')) return;
+    var element = document.createElement("input");
+    element.type = 'button';
+    element.value = 'Copy Markdown';
+    element.id = 'extensionCopyButtonMarkdown'
+    element.style.marginRight="20px";
+    element.onclick = function() {
+      var title = document.getElementsByClassName('js-issue-title')[0].innerText;
+      var href = window.location.href;
+      var id = href.substr(href.lastIndexOf('/') + 1);
+
+      var div = document.createElement('div');
+      div.appendChild(document.createTextNode(title + ' [#' + id + '](' + href + ')'));
+      document.body.appendChild(div);
+
+      const range = document.createRange();
+      range.selectNode(div);
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+      const successful = document.execCommand('copy');
+      document.body.removeChild(div);
     };
     document.getElementsByClassName('Header')[0].prepend(element);
   }
@@ -70,4 +99,5 @@ window.onload=function(){
   }
 
   addCopyButton();
+  addCopyMarkdownButton();
 }


### PR DESCRIPTION
Adds buttons to copy the issue URL and description as a formatted link, or as markdown, for easier pasting.

`Copy Markdown` copies text like `"Issue foo [#123](https://github.com/org/repo/issues/123)"` for pasting in text editors.
`Copy Formatted` copies text like `"Issue foo <a href='https://github.com/org/repo/issues/123'>#123</a>"` for pasting into Slack and Google docs.

Also added a vertical line down the left hand side of the page to make the private pages more visible.

Also made public GitHub repos appear in dark blue.

![image](https://user-images.githubusercontent.com/62522248/98038966-f6332880-1deb-11eb-815a-63c4efa8739e.png)

![image](https://user-images.githubusercontent.com/62522248/98039022-0ba85280-1dec-11eb-9f31-9d16c4bd759e.png)
